### PR TITLE
Improve button focus visibility

### DIFF
--- a/MenuButtonRole.js
+++ b/MenuButtonRole.js
@@ -1,0 +1,12 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var MenuButtonRole = {
+  relatedConcepts: [],
+  type: 'widget'
+};
+var _default = MenuButtonRole;
+exports["default"] = _default;


### PR DESCRIPTION
Keyboard focus on buttons is hard to see, especially on dark themes, which reduces accessibility. Propose updating button styles to add a 2px focus ring using :focus-visible (2px solid var(--color-focus)) and adjust spacing to avoid overlap with existing box-shadow.