### PR TITLE
Improve button focus visibility

### DIFF
--- a/progressbarRole.js
+++ b/progressbarRole.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var progressbarRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'progress'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'status'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'range'], ['roletype', 'widget']]
+};
+var _default = progressbarRole;
+exports.default = _default;


### PR DESCRIPTION
Improve keyboard accessibility by adding visible focus styles for primary and secondary buttons. Proposed change: add a 2px high-contrast outline using :focus-visible to avoid mouse-triggered outlines, and update the Button component CSS and Storybook examples accordingly.