### PR TITLE
Improve primary button contrast

### DIFF
--- a/DisclosureTriangleRole.js
+++ b/DisclosureTriangleRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var DisclosureTriangleRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'summary'
+    }
+  }],
+  type: 'widget'
+};
+var _default = DisclosureTriangleRole;
+exports["default"] = _default;


### PR DESCRIPTION
Primary button currently fails WCAG AA contrast on light backgrounds, which impacts accessibility. Update the --color-primary token to #0A57D6 and hover to #084BB0, then adjust affected styles and snapshots to prevent visual regressions.